### PR TITLE
Revert to 1.5.7

### DIFF
--- a/library/kapacitor
+++ b/library/kapacitor
@@ -1,7 +1,7 @@
 Maintainers: Jonathan A. Sternberg <jonathan@influxdata.com> (@jsternberg),
              j. Emrys Landivar <landivar@gmail.com> (@docmerlin)
 GitRepo: git://github.com/influxdata/influxdata-docker
-GitCommit: 384f6e83c3764607084a38b1c842d240729561d4
+GitCommit: 832dc4b782cdddf5fb0b1362f7afe25a5491aa3f
 
 Tags: 1.4, 1.4.1
 Architectures: amd64, arm32v7, arm64v8
@@ -10,9 +10,9 @@ Directory: kapacitor/1.4
 Tags: 1.4-alpine, 1.4.1-alpine
 Directory: kapacitor/1.4/alpine
 
-Tags: 1.5, 1.5.8, latest
+Tags: 1.5, 1.5.7, latest
 Architectures: amd64, arm32v7, arm64v8
 Directory: kapacitor/1.5
 
-Tags: 1.5-alpine, 1.5.8-alpine, alpine
+Tags: 1.5-alpine, 1.5.7-alpine, alpine
 Directory: kapacitor/1.5/alpine


### PR DESCRIPTION
Revert to 1.5.7.
We need to revert kapacitor to 1.5.7 due to a rather large bug in 1.5.8