### PR TITLE
Revert influxdb2 2.9.0 upgrade

### DIFF
--- a/library/influxdb
+++ b/library/influxdb
@@ -4,7 +4,7 @@ Maintainers: Brandon Pfeifer <bpfeifer@influxdata.com> (@bnpfeife),
              Praveenkumar Hemakumar <pkumar@influxdata.com> (@praveen-influx),
              Trevor Hilton <thilton@influxdata.com> (@hiltontj)
 GitRepo: https://github.com/influxdata/influxdata-docker
-GitCommit: 74f0633592894e9245520b947e1b89ccfaa14ced
+GitCommit: 1d9bc3961bee14268e069bf16767a014d2f62c2a
 
 Tags: 1.12, 1.12.4
 Architectures: amd64, arm64v8
@@ -46,21 +46,21 @@ Directory: influxdb/1.11/meta
 Tags: 1.11-meta-alpine, 1.11.9-meta-alpine
 Directory: influxdb/1.11/meta/alpine
 
-Tags: 2.8, 2.8.0
+Tags: 2.7, 2.7.12
+Architectures: amd64, arm64v8
+Directory: influxdb/2.7
+
+Tags: 2.7-alpine, 2.7.12-alpine
+Architectures: amd64, arm64v8
+Directory: influxdb/2.7/alpine
+
+Tags: 2, 2.8, 2.8.0, latest
 Architectures: amd64, arm64v8
 Directory: influxdb/2.8
 
-Tags: 2.8-alpine, 2.8.0-alpine
+Tags: 2-alpine, 2.8-alpine, 2.8.0-alpine, alpine
 Architectures: amd64, arm64v8
 Directory: influxdb/2.8/alpine
-
-Tags: 2, 2.9, 2.9.0, latest
-Architectures: amd64, arm64v8
-Directory: influxdb/2.9
-
-Tags: 2-alpine, 2.9-alpine, 2.9.0-alpine, alpine
-Architectures: amd64, arm64v8
-Directory: influxdb/2.9/alpine
 
 Tags: 3-core, 3.9-core, 3.9.2-core, core
 Architectures: amd64, arm64v8


### PR DESCRIPTION
- Reverts #21362 ("feat: Update influxdb2 image to 2.9.0, remove 2.7.x")
- Restores `library/influxdb` to its prior state (2.7.x retained, 2.9.0 removed)